### PR TITLE
Update Solstice.munki.recipe

### DIFF
--- a/Solstice/Solstice.munki.recipe
+++ b/Solstice/Solstice.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the latest version of Solstice and imports it into Munki.</string>
+    <string>Downloads the latest version of Solstice and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
     <key>Identifier</key>
     <string>com.github.dcoobs-recipes.munki.Solstice</string>
     <key>Input</key>
     <dict>
+        <key>DERIVE_MIN_OS</key>
+        <string>YES</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/%NAME%</string>
         <key>NAME</key>
@@ -31,7 +35,7 @@
         </dict>
     </dict>
     <key>MinimumVersion</key>
-    <string>1.0.0</string>
+    <string>2.7</string>
     <key>ParentRecipe</key>
     <string>com.github.mlbz521.pkg.Solstice</string>
     <key>Process</key>
@@ -73,6 +77,8 @@
                 <array>
                     <string>/Applications/Mersive Solstice.app</string>
                 </array>
+                <key>derive_minimum_os_version</key>
+                <string>%DERIVE_MIN_OS%</string>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Hi, @dcoobs 

The Solstice Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.15

This change requires AutoPkg version 2.7 or a higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/dcoobs-recipes/Solstice/Solstice.munki.recipe                               
Didn't find a recipe for com.github.mlbz521.pkg.Solstice.
Search GitHub AutoPkg repos for a com.github.mlbz521.pkg.Solstice recipe? [y/n]: n
Could not find parent recipe for /Users/paul/Documents/GitHub/AutoPkg Repos/dcoobs-recipes/Solstice/Solstice.munki.recipe

Nothing downloaded, packaged or imported.
paul@paul-C02WV1GDHV2R ~ % autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/dcoobs-recipes/Solstice/Solstice.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/dcoobs-recipes/Solstice/Solstice.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/dcoobs-recipes/Solstice/Solstice.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Fri, 09 Sep 2022 00:22:35 GMT
URLDownloader: Storing new ETag header: "bddd50a53fb9fc2e6aebd2db641f6d9e-8"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/downloads/SolsticeClientMacWeb.zip
Unarchiver
Unarchiver: Guessed archive format 'zip' from filename SolsticeClientMacWeb.zip
Unarchiver: Unarchived /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/downloads/SolsticeClientMacWeb.zip to /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack
FileFinder
FileFinder: Found file match: '/Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/SolsticeClientMacWeb.app' from globbed '/Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/*.app'
FileFinder: Basename match: 'SolsticeClientMacWeb.app'
CodeSignatureVerifier
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/SolsticeClientMacWeb.app: valid on disk
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/SolsticeClientMacWeb.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/SolsticeClientMacWeb.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
EndOfCheckPhase
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/pkgroot/Applications
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/scripts
SolsticeProcessor
SolsticeProcessor: Version: 5.5.34162
SolsticeProcessor: Bundle Identifier: com.mersive.solstice.client
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/pkgroot
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/scripts
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/Solstice-5.5.34162.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/pkgroot/
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Mersive Solstice.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.15
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.mersive.solstice.client', 'CFBundleName': 'Solstice', 'CFBundleShortVersionString': '5.5.34162', 'CFBundleVersion': '', 'minosversion': '10.15', 'path': '/Applications/Mersive Solstice.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.15'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Solstice/Solstice-5.5.34162.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Solstice/Solstice-5.5.34162.pkg
PathDeleter
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/pkgroot
PathDeleter: Deleted /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/unpack
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/receipts/Solstice.munki-receipt-20221221-094135.plist

The following new items were downloaded:
    Download Path                                                                                                  
    -------------                                                                                                  
    /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/downloads/SolsticeClientMacWeb.zip  

The following packages were built:
    Identifier                   Version    Pkg Path                                                                                           
    ----------                   -------    --------                                                                                           
    com.mersive.solstice.client  5.5.34162  /Users/paul/Library/AutoPkg/Cache/com.github.dcoobs-recipes.munki.Solstice/Solstice-5.5.34162.pkg  

The following new items were imported into Munki:
    Name      Version    Catalogs  Pkginfo Path                            Pkg Repo Path                         Icon Repo Path  
    ----      -------    --------  ------------                            -------------                         --------------  
    Solstice  5.5.34162  testing   apps/Solstice/Solstice-5.5.34162.plist  apps/Solstice/Solstice-5.5.34162.pkg
```