### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Avogadro/Avogadro.download.recipe
+++ b/Avogadro/Avogadro.download.recipe
@@ -40,10 +40,6 @@
 			<key>Processor</key>
 			<string>com.github.n8felton.shared/MD5Checksum</string>
 		</dict>
-		<dict>
-    		<key>Processor</key>
-    		<string>EndOfCheckPhase</string>
-    	</dict>
     </array>
 </dict>
 </plist>

--- a/Malwarebytes Breach Remediation-Graphical User Interface/Malwarebytes Breach Remediation-Graphical User Interface.download.recipe
+++ b/Malwarebytes Breach Remediation-Graphical User Interface/Malwarebytes Breach Remediation-Graphical User Interface.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>Downloads latest version of Malwarebytes Breach Remediation-Graphical User Interface DMG.
-    
+
 Modified version of dataJAR recipe (https://github.com/autopkg/dataJAR-recipes/tree/master/Malwarebytes%20Breach%20Remediation-Command%20Line%20Interface)</string>
     <key>Identifier</key>
     <string>com.github.dcoobs-recipes.download.Malwarebytes Breach Remediation-Graphical User Interface</string>
@@ -39,6 +39,10 @@ Modified version of dataJAR recipe (https://github.com/autopkg/dataJAR-recipes/t
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -49,10 +53,6 @@ Modified version of dataJAR recipe (https://github.com/autopkg/dataJAR-recipes/t
                 <key>purge_destination</key>
                 <true/>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
         <dict>
             <key>Processor</key>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.